### PR TITLE
In FprimeProtocol.cpp:deframe(), make buffer no larger than requested…

### DIFF
--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -109,6 +109,10 @@ DeframingProtocol::DeframingStatus FprimeDeframing::deframe(Types::CircularBuffe
         return DeframingProtocol::DEFRAMING_INVALID_CHECKSUM;
     }
     Fw::Buffer buffer = m_interface->allocate(size);
+    // some allocators may return buffers larger than requested
+    // that causes issues in routing. adjust size
+    FW_ASSERT(buffer.getSize() >= size);
+    buffer.setSize(size);
     ring.peek(buffer.getData(), size, FP_FRAME_HEADER_SIZE);
     m_interface->route(buffer);
     return DeframingProtocol::DEFRAMING_STATUS_SUCCESS;


### PR DESCRIPTION
… (as is possible with static memory allocator.

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

A description of the changes contained in the PR.

## Rationale

A rationale for this change. e.g. fixes bug, or most projects need XYZ feature.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
